### PR TITLE
Add code from Paging, Filtering, and Searching module

### DIFF
--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using AutoMapper;
 using Library.API.Entities;
+using Library.API.Helpers;
 using Library.API.Models;
 using Library.API.Services;
 using Microsoft.AspNetCore.Http;
@@ -14,20 +15,15 @@ namespace Library.API.Controllers
     {
         private ILibraryRepository _libraryRepository;
 
-        const int maxAuthorPageSize = 20;
-
         public AuthorsController(ILibraryRepository libraryRepository)
         {
             _libraryRepository = libraryRepository;
         }
 
         [HttpGet()]
-        public IActionResult GetAuthors([FromQuery] int pageNumber = 1, 
-            [FromQuery] int pageSize = 10)
+        public IActionResult GetAuthors(AuthorsResourceParameters authorsResourceParameters)
         {
-            pageSize = (pageSize > maxAuthorPageSize) ? maxAuthorPageSize : pageSize;
-
-            var authorsFromRepo = _libraryRepository.GetAuthors();
+            var authorsFromRepo = _libraryRepository.GetAuthors(authorsResourceParameters);
 
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -28,6 +28,14 @@ namespace Library.API.Controllers
         {
             var authorsFromRepo = _libraryRepository.GetAuthors(authorsResourceParameters);
 
+            var previousPageLink = authorsFromRepo.HasPrevious ?
+                CreateAuthorsResourceUri(authorsResourceParameters,
+                ResourceUriType.PreviousPage) : null;
+
+            var nextPageLink = authorsFromRepo.HasNext ?
+                CreateAuthorsResourceUri(authorsResourceParameters,
+                ResourceUriType.NextPage) : null;
+
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 
             return Ok(authors);

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -23,7 +23,7 @@ namespace Library.API.Controllers
             _urlHelper = urlHelper;
         }
 
-        [HttpGet()]
+        [HttpGet(Name = "GetAuthors")]
         public IActionResult GetAuthors(AuthorsResourceParameters authorsResourceParameters)
         {
             var authorsFromRepo = _libraryRepository.GetAuthors(authorsResourceParameters);
@@ -31,6 +31,37 @@ namespace Library.API.Controllers
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 
             return Ok(authors);
+        }
+
+        private string CreateAuthorsResourceUri(
+            AuthorsResourceParameters authorsResourceParameters,
+            ResourceUriType type)
+        {
+            switch (type)
+            {
+                case ResourceUriType.PreviousPage:
+                    return _urlHelper.Link("GetAuthors",
+                        new
+                        {
+                            pageNumber = authorsResourceParameters.PageNumber - 1,
+                            pageSize = authorsResourceParameters.PageSize
+                        });
+                case ResourceUriType.NextPage:
+                    return _urlHelper.Link("GetAuthors",
+                        new
+                        {
+                            pageNumber = authorsResourceParameters.PageNumber + 1,
+                            pageSize = authorsResourceParameters.PageSize
+                        });
+
+                default:
+                    return _urlHelper.Link("GetAuthors",
+                        new
+                        {
+                            pageNumber = authorsResourceParameters.PageNumber,
+                            pageSize = authorsResourceParameters.PageSize
+                        });
+            }
         }
 
         [HttpGet("{id}", Name = "GetAuthor")]

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -14,10 +14,13 @@ namespace Library.API.Controllers
     public class AuthorsController : Controller
     {
         private ILibraryRepository _libraryRepository;
+        private IUrlHelper _urlHelper;
 
-        public AuthorsController(ILibraryRepository libraryRepository)
+        public AuthorsController(ILibraryRepository libraryRepository,
+            IUrlHelper urlHelper)
         {
             _libraryRepository = libraryRepository;
+            _urlHelper = urlHelper;
         }
 
         [HttpGet()]

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -64,6 +64,7 @@ namespace Library.API.Controllers
                     return _urlHelper.Link("GetAuthors",
                         new
                         {
+                            genre = authorsResourceParameters.Genre,
                             pageNumber = authorsResourceParameters.PageNumber - 1,
                             pageSize = authorsResourceParameters.PageSize
                         });
@@ -71,6 +72,7 @@ namespace Library.API.Controllers
                     return _urlHelper.Link("GetAuthors",
                         new
                         {
+                            genre = authorsResourceParameters.Genre,
                             pageNumber = authorsResourceParameters.PageNumber + 1,
                             pageSize = authorsResourceParameters.PageSize
                         });
@@ -79,6 +81,7 @@ namespace Library.API.Controllers
                     return _urlHelper.Link("GetAuthors",
                         new
                         {
+                            genre = authorsResourceParameters.Genre,
                             pageNumber = authorsResourceParameters.PageNumber,
                             pageSize = authorsResourceParameters.PageSize
                         });

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -64,6 +64,7 @@ namespace Library.API.Controllers
                     return _urlHelper.Link("GetAuthors",
                         new
                         {
+                            searchQuery = authorsResourceParameters.SearchQuery,
                             genre = authorsResourceParameters.Genre,
                             pageNumber = authorsResourceParameters.PageNumber - 1,
                             pageSize = authorsResourceParameters.PageSize
@@ -72,6 +73,7 @@ namespace Library.API.Controllers
                     return _urlHelper.Link("GetAuthors",
                         new
                         {
+                            searchQuery = authorsResourceParameters.SearchQuery,
                             genre = authorsResourceParameters.Genre,
                             pageNumber = authorsResourceParameters.PageNumber + 1,
                             pageSize = authorsResourceParameters.PageSize
@@ -81,6 +83,7 @@ namespace Library.API.Controllers
                     return _urlHelper.Link("GetAuthors",
                         new
                         {
+                            searchQuery = authorsResourceParameters.SearchQuery,
                             genre = authorsResourceParameters.Genre,
                             pageNumber = authorsResourceParameters.PageNumber,
                             pageSize = authorsResourceParameters.PageSize

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -46,6 +46,9 @@ namespace Library.API.Controllers
                 nextPageLink = nextPageLink
             };
 
+            Response.Headers.Add("X-Pagination",
+                Newtonsoft.Json.JsonConvert.SerializeObject(paginationMetadata));
+
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 
             return Ok(authors);

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -14,14 +14,19 @@ namespace Library.API.Controllers
     {
         private ILibraryRepository _libraryRepository;
 
+        const int maxAuthorPageSize = 20;
+
         public AuthorsController(ILibraryRepository libraryRepository)
         {
             _libraryRepository = libraryRepository;
         }
 
         [HttpGet()]
-        public IActionResult GetAuthors()
+        public IActionResult GetAuthors([FromQuery] int pageNumber = 1, 
+            [FromQuery] int pageSize = 10)
         {
+            pageSize = (pageSize > maxAuthorPageSize) ? maxAuthorPageSize : pageSize;
+
             var authorsFromRepo = _libraryRepository.GetAuthors();
 
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -36,6 +36,16 @@ namespace Library.API.Controllers
                 CreateAuthorsResourceUri(authorsResourceParameters,
                 ResourceUriType.NextPage) : null;
 
+            var paginationMetadata = new
+            {
+                totalCount = authorsFromRepo.TotalCount,
+                pageSize = authorsFromRepo.PageSize,
+                currentPage = authorsFromRepo.CurrentPage,
+                totalPages = authorsFromRepo.TotalPages,
+                previousPageLink = previousPageLink,
+                nextPageLink = nextPageLink
+            };
+
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 
             return Ok(authors);

--- a/src/Library.API/Helpers/AuthorsResourceParameters.cs
+++ b/src/Library.API/Helpers/AuthorsResourceParameters.cs
@@ -1,0 +1,23 @@
+﻿namespace Library.API.Helpers
+{
+    public class AuthorsResourceParameters
+    {
+        const int maxPageSize = 20;
+
+        public int PageNumber { get; set; } = 1;
+
+        private int _pageSize = 10;
+
+        public int PageSize
+        {
+            get
+            {
+                return _pageSize;
+            }
+            set
+            {
+                _pageSize = (value > maxPageSize) ? maxPageSize : value;
+            }
+        }
+    }
+}

--- a/src/Library.API/Helpers/AuthorsResourceParameters.cs
+++ b/src/Library.API/Helpers/AuthorsResourceParameters.cs
@@ -21,5 +21,7 @@
         }
 
         public string Genre { get; set; }
+
+        public string SearchQuery { get; set; }
     }
 }

--- a/src/Library.API/Helpers/AuthorsResourceParameters.cs
+++ b/src/Library.API/Helpers/AuthorsResourceParameters.cs
@@ -19,5 +19,7 @@
                 _pageSize = (value > maxPageSize) ? maxPageSize : value;
             }
         }
+
+        public string Genre { get; set; }
     }
 }

--- a/src/Library.API/Helpers/PagedList.cs
+++ b/src/Library.API/Helpers/PagedList.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Library.API.Helpers
+{
+    public class PagedList<T> : List<T>
+    {
+        public int CurrentPage { get; private set; }
+        public int TotalPages { get; private set; }
+        public int PageSize { get; private set; }
+        public int TotalCount { get; private set; }
+
+        public bool HasPrevious
+        {
+            get
+            {
+                return (CurrentPage > 1);
+            }
+        }
+
+        public bool HasNext
+        {
+            get
+            {
+                return (CurrentPage < TotalPages);
+            }
+        }
+
+        public PagedList(List<T> items, int count, int pageNumber, int pageSize)
+        {
+            TotalCount = count;
+            PageSize = pageSize;
+            CurrentPage = pageNumber;
+            TotalPages = (int)Math.Ceiling(count / (double)pageSize);
+            AddRange(items);
+        }
+
+        public static PagedList<T> Create(IQueryable<T> source, int pageNumber, int pageSize)
+        {
+            var count = source.Count();
+            var items = source.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();
+            return new PagedList<T>(items, count, pageNumber, pageSize);
+        }
+    }
+}

--- a/src/Library.API/Helpers/ResourceUriType.cs
+++ b/src/Library.API/Helpers/ResourceUriType.cs
@@ -1,0 +1,8 @@
+﻿namespace Library.API.Helpers
+{
+    public enum ResourceUriType
+    {
+        PreviousPage,
+        NextPage
+    }
+}

--- a/src/Library.API/Services/ILibraryRepository.cs
+++ b/src/Library.API/Services/ILibraryRepository.cs
@@ -7,7 +7,7 @@ namespace Library.API.Services
 {
     public interface ILibraryRepository
     {
-        IEnumerable<Author> GetAuthors(AuthorsResourceParameters authorsResourceParameters);
+        PagedList<Author> GetAuthors(AuthorsResourceParameters authorsResourceParameters);
         Author GetAuthor(Guid authorId);
         IEnumerable<Author> GetAuthors(IEnumerable<Guid> authorIds);
         void AddAuthor(Author author);

--- a/src/Library.API/Services/ILibraryRepository.cs
+++ b/src/Library.API/Services/ILibraryRepository.cs
@@ -1,12 +1,13 @@
-﻿using Library.API.Entities;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Library.API.Entities;
+using Library.API.Helpers;
 
 namespace Library.API.Services
 {
     public interface ILibraryRepository
     {
-        IEnumerable<Author> GetAuthors();
+        IEnumerable<Author> GetAuthors(AuthorsResourceParameters authorsResourceParameters);
         Author GetAuthor(Guid authorId);
         IEnumerable<Author> GetAuthors(IEnumerable<Guid> authorIds);
         void AddAuthor(Author author);

--- a/src/Library.API/Services/LibraryRepository.cs
+++ b/src/Library.API/Services/LibraryRepository.cs
@@ -1,7 +1,8 @@
-﻿using Library.API.Entities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Library.API.Entities;
+using Library.API.Helpers;
 
 namespace Library.API.Services
 {
@@ -64,9 +65,15 @@ namespace Library.API.Services
             return _context.Authors.FirstOrDefault(a => a.Id == authorId);
         }
 
-        public IEnumerable<Author> GetAuthors()
+        public IEnumerable<Author> GetAuthors(
+            AuthorsResourceParameters authorsResourceParameters)
         {
-            return _context.Authors.OrderBy(a => a.FirstName).ThenBy(a => a.LastName);
+            return _context.Authors
+                .OrderBy(a => a.FirstName)
+                .ThenBy(a => a.LastName)
+                .Skip(authorsResourceParameters.PageSize * (authorsResourceParameters.PageNumber - 1))
+                .Take(authorsResourceParameters.PageSize)
+                .ToList();
         }
 
         public IEnumerable<Author> GetAuthors(IEnumerable<Guid> authorIds)

--- a/src/Library.API/Services/LibraryRepository.cs
+++ b/src/Library.API/Services/LibraryRepository.cs
@@ -65,15 +65,16 @@ namespace Library.API.Services
             return _context.Authors.FirstOrDefault(a => a.Id == authorId);
         }
 
-        public IEnumerable<Author> GetAuthors(
+        public PagedList<Author> GetAuthors(
             AuthorsResourceParameters authorsResourceParameters)
         {
-            return _context.Authors
+            var collectionBeforePaging = _context.Authors
                 .OrderBy(a => a.FirstName)
-                .ThenBy(a => a.LastName)
-                .Skip(authorsResourceParameters.PageSize * (authorsResourceParameters.PageNumber - 1))
-                .Take(authorsResourceParameters.PageSize)
-                .ToList();
+                .ThenBy(a => a.LastName);
+
+            return PagedList<Author>.Create(collectionBeforePaging,
+                authorsResourceParameters.PageNumber,
+                authorsResourceParameters.PageSize);
         }
 
         public IEnumerable<Author> GetAuthors(IEnumerable<Guid> authorIds)

--- a/src/Library.API/Services/LibraryRepository.cs
+++ b/src/Library.API/Services/LibraryRepository.cs
@@ -70,7 +70,16 @@ namespace Library.API.Services
         {
             var collectionBeforePaging = _context.Authors
                 .OrderBy(a => a.FirstName)
-                .ThenBy(a => a.LastName);
+                .ThenBy(a => a.LastName).AsQueryable();
+
+            if (!string.IsNullOrEmpty(authorsResourceParameters.Genre))
+            {
+                // trim & ignore casing
+                var genreForWhereClause = authorsResourceParameters.Genre
+                    .Trim().ToLowerInvariant();
+                collectionBeforePaging = collectionBeforePaging
+                    .Where(a => a.Genre.ToLowerInvariant() == genreForWhereClause);
+            }
 
             return PagedList<Author>.Create(collectionBeforePaging,
                 authorsResourceParameters.PageNumber,

--- a/src/Library.API/Services/LibraryRepository.cs
+++ b/src/Library.API/Services/LibraryRepository.cs
@@ -81,6 +81,18 @@ namespace Library.API.Services
                     .Where(a => a.Genre.ToLowerInvariant() == genreForWhereClause);
             }
 
+            if (!string.IsNullOrEmpty(authorsResourceParameters.SearchQuery))
+            {
+                // trim & ignore casing
+                var searchQueryForWhereClause = authorsResourceParameters.SearchQuery
+                    .Trim().ToLowerInvariant();
+
+                collectionBeforePaging = collectionBeforePaging
+                    .Where(a => a.Genre.ToLowerInvariant().Contains(searchQueryForWhereClause)
+                    || a.FirstName.ToLowerInvariant().Contains(searchQueryForWhereClause)
+                    || a.LastName.ToLowerInvariant().Contains(searchQueryForWhereClause));
+            }
+
             return PagedList<Author>.Create(collectionBeforePaging,
                 authorsResourceParameters.PageNumber,
                 authorsResourceParameters.PageSize);

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -5,7 +5,10 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +54,15 @@ namespace Library.API
 
             // register the repository
             services.AddScoped<ILibraryRepository, LibraryRepository>();
+
+            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
+
+            services.AddScoped<IUrlHelper, UrlHelper>(implementationFactory =>
+            {
+                var actionContext =
+                implementationFactory.GetService<IActionContextAccessor>().ActionContext;
+                return new UrlHelper(actionContext);
+            });
 
             // Needed for NLog.Web
             // Call this in case you need aspnet-user-authtype/aspnet-user-identity


### PR DESCRIPTION
Topics covered in this module:

Paging
- pageSize and pageNumber
- Limit pageSize
- Page by default
- Metadata belongs in a custom header

Filtering
- Pass field name & predicate

Searching
- Pass string to search for, API is responsible for the implementation