### PR TITLE
Add code from the Advanced HATEOAS, Media Types, and Versioning module

### DIFF
--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -185,7 +185,7 @@ namespace Library.API.Controllers
 
         [HttpPost(Name = "CreateAuthor")]
         [RequestHeaderMatchesMediaType("Content-Type",
-            new [] { "application/vnd.marvin.author.full+json" })]
+            new[] { "application/vnd.marvin.author.full+json" })]
         public IActionResult CreateAuthor([FromBody] AuthorForCreationDto author)
         {
             if (author == null)

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -219,7 +219,8 @@ namespace Library.API.Controllers
 
         [HttpPost(Name = "CreateAuthorWithDateOfDeath")]
         [RequestHeaderMatchesMediaType("Content-Type",
-            new[] { "application/vnd.marvin.authorwithdateofdeath.full+json" })]
+            new[] { "application/vnd.marvin.authorwithdateofdeath.full+json",
+                    "application/vnd.marvin.authorwithdateofdeath.full+xml" })]
         public IActionResult CreateAuthorWithDateOfDeath(
             [FromBody] AuthorForCreationWithDateOfDeathDto author)
         {

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -47,7 +47,7 @@ namespace Library.API.Controllers
             }
 
             var authorsFromRepo = _libraryRepository.GetAuthors(authorsResourceParameters);
-            
+
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 
             if (mediaType == "application/vnd.marvin.hateoas+json")
@@ -183,7 +183,7 @@ namespace Library.API.Controllers
             return Ok(linkedResourceToReturn);
         }
 
-        [HttpPost]
+        [HttpPost(Name = "CreateAuthor")]
         public IActionResult CreateAuthor([FromBody] AuthorForCreationDto author)
         {
             if (author == null)

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -31,7 +31,8 @@ namespace Library.API.Controllers
         }
 
         [HttpGet(Name = "GetAuthors")]
-        public IActionResult GetAuthors(AuthorsResourceParameters authorsResourceParameters)
+        public IActionResult GetAuthors(AuthorsResourceParameters authorsResourceParameters,
+            [FromHeader(Name = "Accept")] string mediaType)
         {
             if (!_propertyMappingService.ValidMappingExistsFor<AuthorDto, Author>
                 (authorsResourceParameters.OrderBy))
@@ -46,43 +47,70 @@ namespace Library.API.Controllers
             }
 
             var authorsFromRepo = _libraryRepository.GetAuthors(authorsResourceParameters);
-
-            var paginationMetadata = new
-            {
-                totalCount = authorsFromRepo.TotalCount,
-                pageSize = authorsFromRepo.PageSize,
-                currentPage = authorsFromRepo.CurrentPage,
-                totalPages = authorsFromRepo.TotalPages,
-            };
-
-            Response.Headers.Add("X-Pagination",
-                Newtonsoft.Json.JsonConvert.SerializeObject(paginationMetadata));
-
+            
             var authors = Mapper.Map<IEnumerable<AuthorDto>>(authorsFromRepo);
 
-            var links = CreateLinksForAuthors(authorsResourceParameters,
-                authorsFromRepo.HasNext, authorsFromRepo.HasPrevious);
-
-            var shapedAuthors = authors.ShapeData(authorsResourceParameters.Fields);
-
-            var shapedAuthorsWithLinks = shapedAuthors.Select(author =>
+            if (mediaType == "application/vnd.marvin.hateoas+json")
             {
-                var authorAsDictionary = author as IDictionary<string, object>;
-                var authorLinks = CreateLinksForAuthor(
-                    (Guid)authorAsDictionary["Id"], authorsResourceParameters.Fields);
+                var paginationMetadata = new
+                {
+                    totalCount = authorsFromRepo.TotalCount,
+                    pageSize = authorsFromRepo.PageSize,
+                    currentPage = authorsFromRepo.CurrentPage,
+                    totalPages = authorsFromRepo.TotalPages,
+                };
 
-                authorAsDictionary.Add("links", authorLinks);
+                Response.Headers.Add("X-Pagination",
+                    Newtonsoft.Json.JsonConvert.SerializeObject(paginationMetadata));
 
-                return authorAsDictionary;
-            });
+                var links = CreateLinksForAuthors(authorsResourceParameters,
+                    authorsFromRepo.HasNext, authorsFromRepo.HasPrevious);
 
-            var linkedCollectionResource = new
+                var shapedAuthors = authors.ShapeData(authorsResourceParameters.Fields);
+
+                var shapedAuthorsWithLinks = shapedAuthors.Select(author =>
+                {
+                    var authorAsDictionary = author as IDictionary<string, object>;
+                    var authorLinks = CreateLinksForAuthor(
+                        (Guid)authorAsDictionary["Id"], authorsResourceParameters.Fields);
+
+                    authorAsDictionary.Add("links", authorLinks);
+
+                    return authorAsDictionary;
+                });
+
+                var linkedCollectionResource = new
+                {
+                    value = shapedAuthorsWithLinks,
+                    links = links
+                };
+
+                return Ok(linkedCollectionResource);
+            }
+            else
             {
-                value = shapedAuthorsWithLinks,
-                links = links
-            };
+                var previousPageLink = authorsFromRepo.HasPrevious ?
+                    CreateAuthorsResourceUri(authorsResourceParameters,
+                    ResourceUriType.PreviousPage) : null;
 
-            return Ok(linkedCollectionResource);
+                var nextPageLink = authorsFromRepo.HasNext ?
+                    CreateAuthorsResourceUri(authorsResourceParameters,
+                    ResourceUriType.NextPage) : null;
+
+                var paginationMetadata = new
+                {
+                    previousPageLink = previousPageLink,
+                    nextPageLink = nextPageLink,
+                    totalCount = authorsFromRepo.TotalCount,
+                    pageSize = authorsFromRepo.PageSize,
+                    totalPages = authorsFromRepo.TotalPages
+                };
+
+                Response.Headers.Add("X-Pagination",
+                    Newtonsoft.Json.JsonConvert.SerializeObject(paginationMetadata));
+
+                return Ok(authors.ShapeData(authorsResourceParameters.Fields));
+            }
         }
 
         private string CreateAuthorsResourceUri(

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -184,7 +184,44 @@ namespace Library.API.Controllers
         }
 
         [HttpPost(Name = "CreateAuthor")]
+        [RequestHeaderMatchesMediaType("Content-Type",
+            new [] { "application/vnd.marvin.author.full+json" })]
         public IActionResult CreateAuthor([FromBody] AuthorForCreationDto author)
+        {
+            if (author == null)
+            {
+                return BadRequest();
+            }
+
+            var authorEntity = Mapper.Map<Author>(author);
+
+            _libraryRepository.AddAuthor(authorEntity);
+
+            if (!_libraryRepository.Save())
+            {
+                throw new Exception("Creating an author failed on save.");
+                // return StatusCode(500, "A problem happened with handling your request.");
+            }
+
+            var authorToReturn = Mapper.Map<AuthorDto>(authorEntity);
+
+            var links = CreateLinksForAuthor(authorToReturn.Id, null);
+
+            var linkedResourceToReturn = authorToReturn.ShapeData(null)
+                as IDictionary<string, object>;
+
+            linkedResourceToReturn.Add("links", links);
+
+            return CreatedAtRoute("GetAuthor",
+                new { id = linkedResourceToReturn["Id"] },
+                linkedResourceToReturn);
+        }
+
+        [HttpPost(Name = "CreateAuthorWithDateOfDeath")]
+        [RequestHeaderMatchesMediaType("Content-Type",
+            new[] { "application/vnd.marvin.authorwithdateofdeath.full+json" })]
+        public IActionResult CreateAuthorWithDateOfDeath(
+            [FromBody] AuthorForCreationWithDateOfDeathDto author)
         {
             if (author == null)
             {

--- a/src/Library.API/Controllers/AuthorsController.cs
+++ b/src/Library.API/Controllers/AuthorsController.cs
@@ -221,6 +221,7 @@ namespace Library.API.Controllers
         [RequestHeaderMatchesMediaType("Content-Type",
             new[] { "application/vnd.marvin.authorwithdateofdeath.full+json",
                     "application/vnd.marvin.authorwithdateofdeath.full+xml" })]
+        // [RequestHeaderMatchesMediaType("Accept", new[] { "..." })]
         public IActionResult CreateAuthorWithDateOfDeath(
             [FromBody] AuthorForCreationWithDateOfDeathDto author)
         {

--- a/src/Library.API/Controllers/RootController.cs
+++ b/src/Library.API/Controllers/RootController.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Library.API.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Library.API.Controllers
+{
+    [Route("api")]
+    public class RootController : Controller
+    {
+        private IUrlHelper _urlHelper;
+
+        public RootController(IUrlHelper urlHelper)
+        {
+            _urlHelper = urlHelper;
+        }
+
+        [HttpGet(Name = "GetRoot")]
+        public IActionResult GetRoot([FromHeader(Name = "Accept")] string mediaType)
+        {
+            if (mediaType == "application/vnd.marvin.hateoas+json")
+            {
+                var links = new List<LinkDto>();
+
+                links.Add(
+                    new LinkDto(_urlHelper.Link("GetRoot", new { }),
+                    "self",
+                    "GET"));
+
+                links.Add(
+                    new LinkDto(_urlHelper.Link("GetAuthors", new { }),
+                    "authors",
+                    "GET"));
+
+                links.Add(
+                    new LinkDto(_urlHelper.Link("CreateAuthor", new { }),
+                    "create_author",
+                    "POST"));
+
+                return Ok(links);
+            }
+
+            return NoContent();
+        }
+    }
+}

--- a/src/Library.API/Entities/Author.cs
+++ b/src/Library.API/Entities/Author.cs
@@ -20,6 +20,8 @@ namespace Library.API.Entities
         [Required]
         public DateTimeOffset DateOfBirth { get; set; }
 
+        public DateTimeOffset? DateOfDeath { get; set; }
+
         [Required]
         [MaxLength(50)]
         public string Genre { get; set; }

--- a/src/Library.API/Helpers/DateTimeOffsetExtensions.cs
+++ b/src/Library.API/Helpers/DateTimeOffsetExtensions.cs
@@ -7,12 +7,19 @@ namespace Library.API.Helpers
 {
     public static class DateTimeOffsetExtensions
     {
-        public static int GetCurrentAge(this DateTimeOffset dateTimeOffset)
+        public static int GetCurrentAge(this DateTimeOffset dateTimeOffset,
+            DateTimeOffset? dateOfDeath)
         {
-            var currentDate = DateTime.UtcNow;
-            int age = currentDate.Year - dateTimeOffset.Year;
+            var dateToCalculateTo = DateTime.UtcNow;
 
-            if (currentDate < dateTimeOffset.AddYears(age))
+            if (dateOfDeath != null)
+            {
+                dateToCalculateTo = dateOfDeath.Value.UtcDateTime;
+            }
+
+            int age = dateToCalculateTo.Year - dateTimeOffset.Year;
+
+            if (dateToCalculateTo < dateTimeOffset.AddYears(age))
             {
                 age--;
             }

--- a/src/Library.API/Helpers/RequestHeaderMatchesMediaTypeAttribute.cs
+++ b/src/Library.API/Helpers/RequestHeaderMatchesMediaTypeAttribute.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.ActionConstraints;
 
 namespace Library.API.Helpers
 {
+    [AttributeUsage(AttributeTargets.All, Inherited = true, AllowMultiple = true)]
     public class RequestHeaderMatchesMediaTypeAttribute : Attribute, IActionConstraint
     {
         private string _requestHeaderToMatch;

--- a/src/Library.API/Helpers/RequestHeaderMatchesMediaTypeAttribute.cs
+++ b/src/Library.API/Helpers/RequestHeaderMatchesMediaTypeAttribute.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Library.API.Helpers
+{
+    public class RequestHeaderMatchesMediaTypeAttribute : Attribute, IActionConstraint
+    {
+        private string _requestHeaderToMatch;
+        private string[] _mediaTypes;
+
+        public RequestHeaderMatchesMediaTypeAttribute(string requestHeaderToMatch,
+            string[] mediaTypes)
+        {
+            _requestHeaderToMatch = requestHeaderToMatch;
+            _mediaTypes = mediaTypes;
+        }
+
+        public int Order
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public bool Accept(ActionConstraintContext context)
+        {
+            var requestHeaders = context.RouteContext.HttpContext.Request.Headers;
+
+            if (!requestHeaders.ContainsKey(_requestHeaderToMatch))
+            {
+                return false;
+            }
+
+            // if one of the media types matches, return true
+            foreach (var mediaType in _mediaTypes)
+            {
+                var mediaTypeMatches = string.Equals(requestHeaders[_requestHeaderToMatch].ToString(),
+                    mediaType, StringComparison.OrdinalIgnoreCase);
+
+                if (mediaTypeMatches)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Library.API/Migrations/20170518173336_AddDateOfDeathToAuthor.Designer.cs
+++ b/src/Library.API/Migrations/20170518173336_AddDateOfDeathToAuthor.Designer.cs
@@ -8,9 +8,10 @@ using Library.API.Entities;
 namespace Library.API.Migrations
 {
     [DbContext(typeof(LibraryContext))]
-    partial class LibraryContextModelSnapshot : ModelSnapshot
+    [Migration("20170518173336_AddDateOfDeathToAuthor")]
+    partial class AddDateOfDeathToAuthor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.1.1")

--- a/src/Library.API/Migrations/20170518173336_AddDateOfDeathToAuthor.cs
+++ b/src/Library.API/Migrations/20170518173336_AddDateOfDeathToAuthor.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Library.API.Migrations
+{
+    public partial class AddDateOfDeathToAuthor : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DateOfDeath",
+                table: "Authors",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DateOfDeath",
+                table: "Authors");
+        }
+    }
+}

--- a/src/Library.API/Models/AuthorForCreationWithDateOfDeathDto.cs
+++ b/src/Library.API/Models/AuthorForCreationWithDateOfDeathDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Library.API.Models
+{
+    public class AuthorForCreationWithDateOfDeathDto
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public DateTimeOffset DateOfBirth { get; set; }
+        public DateTimeOffset? DateOfDeath { get; set; }
+        public string Genre { get; set; }
+    }
+}

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Library.API.Entities;
+﻿using System.Linq;
+using Library.API.Entities;
 using Library.API.Helpers;
 using Library.API.Services;
 using Microsoft.AspNetCore.Builder;
@@ -45,6 +46,14 @@ namespace Library.API
                 setupAction.ReturnHttpNotAcceptable = true;
                 setupAction.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
                 setupAction.InputFormatters.Add(new XmlDataContractSerializerInputFormatter());
+
+                var jsonOutputFormatter = setupAction.OutputFormatters
+                    .OfType<JsonOutputFormatter>().FirstOrDefault();
+
+                if (jsonOutputFormatter != null)
+                {
+                    jsonOutputFormatter.SupportedMediaTypes.Add("application/vnd.marvin.hateoas+json");
+                }
             })
             .AddJsonOptions(options =>
             {

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -47,6 +47,17 @@ namespace Library.API
                 setupAction.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
                 setupAction.InputFormatters.Add(new XmlDataContractSerializerInputFormatter());
 
+                var jsonInputFormatter = setupAction.InputFormatters
+                .OfType<JsonInputFormatter>().FirstOrDefault();
+
+                if (jsonInputFormatter != null)
+                {
+                    jsonInputFormatter.SupportedMediaTypes
+                    .Add("application/vnd.marvin.author.full+json");
+                    jsonInputFormatter.SupportedMediaTypes
+                    .Add("application/vnd.marvin.authorwithdateofdeath.full+json");
+                }
+
                 var jsonOutputFormatter = setupAction.OutputFormatters
                     .OfType<JsonOutputFormatter>().FirstOrDefault();
 
@@ -137,6 +148,8 @@ namespace Library.API
                 cfg.CreateMap<Entities.Book, Models.BookDto>();
 
                 cfg.CreateMap<Models.AuthorForCreationDto, Entities.Author>();
+
+                cfg.CreateMap<Models.AuthorForCreationWithDateOfDeathDto, Entities.Author>();
 
                 cfg.CreateMap<Models.BookForCreationDto, Entities.Book>();
 

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -132,7 +132,7 @@ namespace Library.API
                     .ForMember(dest => dest.Name, opt => opt.MapFrom(src =>
                     $"{src.FirstName} {src.LastName}"))
                     .ForMember(dest => dest.Age, opt => opt.MapFrom(src =>
-                    src.DateOfBirth.GetCurrentAge()));
+                    src.DateOfBirth.GetCurrentAge(src.DateOfDeath)));
 
                 cfg.CreateMap<Entities.Book, Models.BookDto>();
 

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -45,7 +45,13 @@ namespace Library.API
             {
                 setupAction.ReturnHttpNotAcceptable = true;
                 setupAction.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
-                setupAction.InputFormatters.Add(new XmlDataContractSerializerInputFormatter());
+                // setupAction.InputFormatters.Add(new XmlDataContractSerializerInputFormatter());
+
+                var xmlDataContractSerializerInputFormatter =
+                new XmlDataContractSerializerInputFormatter();
+                xmlDataContractSerializerInputFormatter.SupportedMediaTypes
+                    .Add("application/vnd.marvin.authorwithdateofdeath.full+xml");
+                setupAction.InputFormatters.Add(xmlDataContractSerializerInputFormatter);                    
 
                 var jsonInputFormatter = setupAction.InputFormatters
                 .OfType<JsonInputFormatter>().FirstOrDefault();


### PR DESCRIPTION
Hypermedia as the Engine of Application State
- A custom media type is warranted when the response should contain HATEOAS-related information

Use custom media types for resource representations
- `application/vnd.marvin.author.friendly+json`

HATEOAS and media types used together lead to evolvability and solve versioning issues in a RESTful manner
- `application/vnd.marvin.author.friendly.v1+json`