### PR TITLE
Add code from the Caching and Concurrency module

### DIFF
--- a/src/Library.API/Library.API.csproj
+++ b/src/Library.API/Library.API.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Marvin.Cache.Headers" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/Library.API/Library.API.csproj
+++ b/src/Library.API/Library.API.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.0.2" />
+    <PackageReference Include="Marvin.Cache.Headers" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -104,6 +104,8 @@ namespace Library.API
             // Call this in case you need aspnet-user-authtype/aspnet-user-identity
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
+            services.AddResponseCaching();
+
             services.AddHttpCacheHeaders(
                 (expirationModelOptions)
                 =>

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -104,7 +104,17 @@ namespace Library.API
             // Call this in case you need aspnet-user-authtype/aspnet-user-identity
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
-            services.AddHttpCacheHeaders();
+            services.AddHttpCacheHeaders(
+                (expirationModelOptions)
+                =>
+                {
+                    expirationModelOptions.MaxAge = 600;
+                },
+                (validationModelOptions)
+                =>
+                {
+                    validationModelOptions.AddMustRevalidate = true;
+                });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -103,6 +103,8 @@ namespace Library.API
             // Needed for NLog.Web
             // Call this in case you need aspnet-user-authtype/aspnet-user-identity
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+            services.AddHttpCacheHeaders();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -165,6 +167,8 @@ namespace Library.API
             });
 
             libraryContext.EnsureSeedDataForContext();
+
+            app.UseHttpCacheHeaders();
 
             app.UseMvc();
         }

--- a/src/Library.API/Startup.cs
+++ b/src/Library.API/Startup.cs
@@ -180,6 +180,8 @@ namespace Library.API
 
             libraryContext.EnsureSeedDataForContext();
 
+            app.UseResponseCaching();
+
             app.UseHttpCacheHeaders();
 
             app.UseMvc();


### PR DESCRIPTION
Each response must state whether or not it can be cached.

Caching: _expiration model_
- Allows the server to state how long a response is considered fresh
- `Cache-Control` header

Caching: _validation model_
- Used to validate the freshness of a response that's been cached
- `ETag`, `Last-Modified` headers

Use ETags for optimistic concurrency